### PR TITLE
Migrate statistics request to a YAML notification in >=Orange3.24

### DIFF
--- a/notifications/13092019-statisticsRequest.yml
+++ b/notifications/13092019-statisticsRequest.yml
@@ -1,0 +1,11 @@
+requirements:
+    installed:
+        - Orange3>3.23
+    local_config:
+        - error-reporting/send-statistics==false 
+icon: "canvas/icons/statistics-request.png" 
+title: "Anonymous Usage Statistics"
+text: "Do you wish to opt-in to sharing statistics about how you use Orange? All information is anonymized and used exclusively for understanding how users interact with Orange."
+link: "orange://enable-statistics"
+accept_button_label: 'Ok'
+reject_button_label: 'No'


### PR DESCRIPTION
The hardcoded statistics request notification in Orange3 should be removed.
This notification, coupled with the `orange://enable-statistics` action should replace its functionality.