### PR TITLE
Adjust dates such that they are specified inclusively

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ accept_button_label: [string]
 reject_button_label: [string]
 ```
 
+The start and end dates are **inclusive**.
+
 Supported operators: `<`, `>`, `<=`, `>=`, `==`
 
 In an installed requirement:


### PR DESCRIPTION
In Orange, start and end are specified exclusively as opposed to inclusively.
By adjusting the start and end date when generating the feed, the specified dates in YAML are now inclusive, without having to change code in Orange.