### PR TITLE
Tutorial notifications

### DIFF
--- a/notifications/16102019-tutorialOffer.yml
+++ b/notifications/16102019-tutorialOffer.yml
@@ -1,0 +1,9 @@
+requirements:
+    local_config:
+        - startup/launch-count<5
+icon: "canvas/icons/statistics-request.png"
+title: "Orange Tutorials"
+text: "New to Orange? Get started by checking out our video tutorials!"
+link: "https://www.youtube.com/watch?v=HXjnDIgGDuI&list=PLmNPvQr9Tf-ZSDLwOzxpvY-HrE0yv-8Fy"
+accept_button_label: 'Ok'
+reject_button_label: 'No'


### PR DESCRIPTION
At the Friday meeting long ago we have been talking about having a notification with the link to a tutorial for new users. Here is my idea of the text. Any comments welcome. 

orange-notification-feed looks great. I was just a little confused with `local_config` options. Is there a possibility to make documentation with all options available?